### PR TITLE
fix: allow cross origin requests for `graphql`

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -4,7 +4,7 @@ class GraphqlController < ApplicationController
   # If accessing from outside this domain, nullify the session
   # This allows for outside API access while preventing CSRF attacks,
   # but you'll have to authenticate your user separately
-  # protect_from_forgery with: :null_session
+  protect_from_forgery with: :null_session
 
   def execute
     variables = prepare_variables(params[:variables])


### PR DESCRIPTION
allows cross origin requests for `graphql`